### PR TITLE
Add S3 State Locking Input

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -190,6 +190,7 @@ terraform:
 | <a name="input_prevent_unencrypted_uploads"></a> [prevent\_unencrypted\_uploads](#input\_prevent\_unencrypted\_uploads) | Prevent uploads of unencrypted objects to S3 | `bool` | `true` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_s3_state_lock_enabled"></a> [s3\_state\_lock\_enabled](#input\_s3\_state\_lock\_enabled) | Whether to use S3 for state lock. If true, the DynamoDB table will not be created. | `bool` | `false` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/src/iam.tf
+++ b/src/iam.tf
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "tfstate" {
   }
 
   dynamic "statement" {
-    for_each = var.dynamodb_enabled ? [1] : []
+    for_each = local.dynamodb_enabled ? [1] : []
     content {
       sid    = "TerraformStateBackendDynamoDbTable"
       effect = "Allow"

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,16 +1,22 @@
 locals {
   enabled = module.this.enabled
+
+  # If S3 state lock is enabled, always disable DynamoDB
+  dynamodb_enabled = var.s3_state_lock_enabled ? false : var.dynamodb_enabled
 }
 
 module "tfstate_backend" {
   source  = "cloudposse/tfstate-backend/aws"
   version = "1.6.0"
 
+  enabled = local.enabled
+
   force_destroy                     = var.force_destroy
   prevent_unencrypted_uploads       = var.prevent_unencrypted_uploads
   enable_point_in_time_recovery     = var.enable_point_in_time_recovery
   bucket_ownership_enforced_enabled = false
-  dynamodb_enabled                  = var.dynamodb_enabled
+  dynamodb_enabled                  = local.dynamodb_enabled
+  s3_state_lock_enabled             = var.s3_state_lock_enabled
 
   context = module.this.context
 }

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -15,17 +15,17 @@ output "tfstate_backend_s3_bucket_arn" {
 
 output "tfstate_backend_dynamodb_table_name" {
   description = "Terraform state DynamoDB table name"
-  value       = var.dynamodb_enabled ? module.tfstate_backend.dynamodb_table_name : ""
+  value       = local.dynamodb_enabled ? module.tfstate_backend.dynamodb_table_name : ""
 }
 
 output "tfstate_backend_dynamodb_table_id" {
   description = "Terraform state DynamoDB table ID"
-  value       = var.dynamodb_enabled ? module.tfstate_backend.dynamodb_table_id : ""
+  value       = local.dynamodb_enabled ? module.tfstate_backend.dynamodb_table_id : ""
 }
 
 output "tfstate_backend_dynamodb_table_arn" {
   description = "Terraform state DynamoDB table ARN"
-  value       = var.dynamodb_enabled ? module.tfstate_backend.dynamodb_table_arn : ""
+  value       = local.dynamodb_enabled ? module.tfstate_backend.dynamodb_table_arn : ""
 }
 
 output "tfstate_backend_access_role_arns" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -50,3 +50,9 @@ variable "dynamodb_enabled" {
   default     = true
   description = "Whether to create the DynamoDB table."
 }
+
+variable "s3_state_lock_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to use S3 for state lock. If true, the DynamoDB table will not be created."
+}


### PR DESCRIPTION
## what
This pull request introduces support for using S3-based state locking as an alternative to DynamoDB for Terraform state management. It adds a new variable to control this behavior and ensures that DynamoDB resources are not created when S3 state locking is enabled. The changes also make sure that documentation and outputs reflect the new logic.

**Support for S3 State Locking:**

* Added a new variable `s3_state_lock_enabled` to allow switching between DynamoDB and S3 for state locking, with documentation updates in `src/README.md` and variable definition in `src/variables.tf`. [[1]](diffhunk://#diff-e1d5879ce3e222eb0cdd43051fb8c34c00796467acb091d0b3fa939ee3355cb5R193) [[2]](diffhunk://#diff-e64d396480ef61e94c68b45e4940f63bdb28cce844c90404d648122910254904R53-R58)
* Updated local logic in `src/main.tf` to disable DynamoDB automatically when `s3_state_lock_enabled` is true, and passed this value to the `tfstate_backend` module.

**Conditional Resource and Output Handling:**

* Modified the IAM policy document in `src/iam.tf` to use the new local variable for enabling DynamoDB, ensuring the correct resource is referenced.
* Updated outputs in `src/outputs.tf` to use the local DynamoDB enabled flag, so DynamoDB outputs are empty when S3 state locking is used.

## why
- Fix issues using S3 statefile locking rather than DynamoDB

## references
- Fixes #33 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added option to enable S3-based state locking via a new input; when enabled, DynamoDB state-lock resources are not created.
  * Module now honors the new setting across configuration, ensuring consistent behavior.
* Documentation
  * Updated README to document the new input and its behavior.
* Refactor
  * Updated internal logic so DynamoDB-related outputs and permissions are conditionally exposed based on the new setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->