### PR TITLE
Update tfstate_backend module version to 1.7.1

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -7,7 +7,7 @@ locals {
 
 module "tfstate_backend" {
   source  = "cloudposse/tfstate-backend/aws"
-  version = "1.7.0"
+  version = "1.7.1"
 
   enabled = local.enabled
 


### PR DESCRIPTION
## what
* Update tfstate_backend module version to 1.7.1
* Add depends_on to S3 bucket locking resource

## why
* Locking can be enabled only after `versioning` is enabled
* Fix cold start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend infrastructure module to the latest patch version for improved stability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->