### PR TITLE
fix: use per-account role name templates instead of global template

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -14,7 +14,7 @@ This release fixes breaking changes unintentionally introduced in v2 when the `a
 
 - **IAM user deny statement**: Restored the default deny statement for IAM users that was present in pre-v2 versions. This denies all IAM users except those explicitly allowed.
 
-- **`use_organization_id` default**: Changed default from `true` back to `false` to restore pre-v2 behavior.
+- **`use_organization_id` default**: The `use_organization_id` variable was introduced in v2 with an incorrect default of `true`. This PR corrects the default to `false` to match the pre-v2 behavior of listing individual account root ARNs.
 
 ### Impact by Customer Type
 

--- a/src/iam.tf
+++ b/src/iam.tf
@@ -16,9 +16,13 @@ locals {
   #    arn:aws:iam::123456789012:role/acme-core-gbl-root-admin
   caller_arn = coalesce(data.awsutils_caller_identity.current.eks_role_arn, data.awsutils_caller_identity.current.arn)
 
-  # IAM role name template with two placeholders: %s for account name, %s for role name
+  # Fallback IAM role name template used when per-account templates are not available
+  # (i.e., when account_map_enabled is false and no iam_role_arn_templates provided)
   # Format: {namespace}-{tenant}-gbl-{account}-{role} (e.g., acme-core-gbl-identity-admin)
   # Uses "gbl" for environment since IAM roles are global resources
+  #
+  # When account_map_enabled is true, the account-map component provides per-account
+  # iam_role_arn_templates which take precedence over this fallback template.
   iam_role_arn_template = join(module.this.delimiter, compact([
     module.this.namespace,
     module.this.tenant,

--- a/src/modules/assume-role-policy/main.tf
+++ b/src/modules/assume-role-policy/main.tf
@@ -40,25 +40,27 @@ locals {
   ) } : {}
 
   # Convert allowed_roles map (account_name/id -> [role_names]) to ARN patterns
+  # Uses per-account templates from iam_role_arn_templates when available
   allowed_role_arns = local.enabled ? distinct(flatten([
     for account_key, role_names in var.allowed_roles : [
       for role_name in role_names : (
         role_name == "*" ?
         format("arn:%s:iam::%s:role/*", data.aws_partition.current[0].partition, local.get_account_id[account_key]) :
         format("arn:%s:iam::%s:role/%s", data.aws_partition.current[0].partition, local.get_account_id[account_key],
-        var.iam_role_arn_template != null ? format(var.iam_role_arn_template, role_name) : role_name)
+        contains(keys(var.iam_role_arn_templates), account_key) ? format(var.iam_role_arn_templates[account_key], role_name) : role_name)
       )
     ]
   ])) : []
 
   # Convert denied_roles map (account_name/id -> [role_names]) to ARN patterns
+  # Uses per-account templates from iam_role_arn_templates when available
   denied_role_arns = local.enabled ? distinct(flatten([
     for account_key, role_names in var.denied_roles : [
       for role_name in role_names : (
         role_name == "*" ?
         format("arn:%s:iam::%s:role/*", data.aws_partition.current[0].partition, local.get_account_id[account_key]) :
         format("arn:%s:iam::%s:role/%s", data.aws_partition.current[0].partition, local.get_account_id[account_key],
-        var.iam_role_arn_template != null ? format(var.iam_role_arn_template, role_name) : role_name)
+        contains(keys(var.iam_role_arn_templates), account_key) ? format(var.iam_role_arn_templates[account_key], role_name) : role_name)
       )
     ]
   ])) : []

--- a/src/modules/assume-role-policy/main.tf
+++ b/src/modules/assume-role-policy/main.tf
@@ -40,27 +40,27 @@ locals {
   ) } : {}
 
   # Convert allowed_roles map (account_name/id -> [role_names]) to ARN patterns
-  # Uses per-account templates from iam_role_arn_templates when available
+  # Template uses two placeholders: first %s = account name, second %s = role name
   allowed_role_arns = local.enabled ? distinct(flatten([
     for account_key, role_names in var.allowed_roles : [
       for role_name in role_names : (
         role_name == "*" ?
         format("arn:%s:iam::%s:role/*", data.aws_partition.current[0].partition, local.get_account_id[account_key]) :
         format("arn:%s:iam::%s:role/%s", data.aws_partition.current[0].partition, local.get_account_id[account_key],
-        contains(keys(var.iam_role_arn_templates), account_key) ? format(var.iam_role_arn_templates[account_key], role_name) : role_name)
+        var.iam_role_arn_template != null ? format(var.iam_role_arn_template, account_key, role_name) : role_name)
       )
     ]
   ])) : []
 
   # Convert denied_roles map (account_name/id -> [role_names]) to ARN patterns
-  # Uses per-account templates from iam_role_arn_templates when available
+  # Template uses two placeholders: first %s = account name, second %s = role name
   denied_role_arns = local.enabled ? distinct(flatten([
     for account_key, role_names in var.denied_roles : [
       for role_name in role_names : (
         role_name == "*" ?
         format("arn:%s:iam::%s:role/*", data.aws_partition.current[0].partition, local.get_account_id[account_key]) :
         format("arn:%s:iam::%s:role/%s", data.aws_partition.current[0].partition, local.get_account_id[account_key],
-        contains(keys(var.iam_role_arn_templates), account_key) ? format(var.iam_role_arn_templates[account_key], role_name) : role_name)
+        var.iam_role_arn_template != null ? format(var.iam_role_arn_template, account_key, role_name) : role_name)
       )
     ]
   ])) : []

--- a/src/modules/assume-role-policy/variables.tf
+++ b/src/modules/assume-role-policy/variables.tf
@@ -84,15 +84,13 @@ variable "account_map" {
   }
 }
 
-variable "iam_role_arn_templates" {
-  type        = map(string)
+variable "iam_role_arn_template" {
+  type        = string
   description = <<-EOT
-    Map of account name/ID to IAM role name template for that account.
-    Each template should be a format string with a single %s placeholder for the role name.
-    Example: { "identity" = "acme-gbl-identity-%s", "dev" = "acme-gbl-dev-%s" }
-
-    This allows different accounts to have different role naming conventions.
-    When an account is not found in this map, the role name is used as-is.
+    Template for constructing IAM role names from account and role names.
+    Should be a format string with two %s placeholders: first for account name, second for role name.
+    Example: "acme-gbl-%s-%s" would produce role names like "acme-gbl-identity-admin"
+    If null, role names are used as-is (assumed to be full role names).
   EOT
-  default     = {}
+  default     = null
 }

--- a/src/modules/assume-role-policy/variables.tf
+++ b/src/modules/assume-role-policy/variables.tf
@@ -68,7 +68,7 @@ variable "use_organization_id" {
     If `false`, each account root is listed individually in the principals block, which may hit
     the trust policy size limit in larger organizations.
   EOT
-  default     = true
+  default     = false
 }
 
 variable "account_map" {

--- a/src/modules/assume-role-policy/variables.tf
+++ b/src/modules/assume-role-policy/variables.tf
@@ -73,8 +73,9 @@ variable "use_organization_id" {
 
 variable "account_map" {
   type = object({
-    full_account_map       = map(string)
-    iam_role_arn_templates = optional(map(string), {})
+    full_account_map              = map(string)
+    iam_role_arn_templates        = optional(map(string), {})
+    identity_account_account_name = optional(string, "identity")
   })
   description = <<-EOT
     Account map for resolving account names to account IDs and IAM role ARN templates.
@@ -83,11 +84,33 @@ variable "account_map" {
     - full_account_map: Map of account name to account ID
     - iam_role_arn_templates: Map of account name to IAM role ARN template with single %s placeholder for role name
       (e.g., { "identity" = "arn:aws:iam::123456789012:role/acme-core-gbl-identity-%s" })
+    - identity_account_account_name: Name of the identity account (default: "identity")
   EOT
   default = {
-    full_account_map       = {}
-    iam_role_arn_templates = {}
+    full_account_map              = {}
+    iam_role_arn_templates        = {}
+    identity_account_account_name = "identity"
   }
+}
+
+variable "team_permission_sets_enabled" {
+  type        = bool
+  description = <<-EOT
+    When true, any roles in the identity account referenced in `allowed_roles` will cause
+    corresponding AWS SSO PermissionSets to be automatically included in the trust policy.
+    This converts role names like "developers" to permission sets like "IdentityDevelopersTeamAccess".
+  EOT
+  default     = true
+}
+
+variable "team_permission_set_name_pattern" {
+  type        = string
+  description = <<-EOT
+    The pattern used to generate the AWS SSO PermissionSet name for each team.
+    Uses Go template syntax with a single %s placeholder for the team name (title-cased).
+    Example: "Identity%sTeamAccess" converts "developers" to "IdentityDevelopersTeamAccess"
+  EOT
+  default     = "Identity%sTeamAccess"
 }
 
 variable "iam_role_arn_template" {

--- a/src/modules/assume-role-policy/variables.tf
+++ b/src/modules/assume-role-policy/variables.tf
@@ -84,13 +84,15 @@ variable "account_map" {
   }
 }
 
-variable "iam_role_arn_template" {
-  type        = string
+variable "iam_role_arn_templates" {
+  type        = map(string)
   description = <<-EOT
-    Template for constructing IAM role ARNs from role names.
-    Should be a format string with a single %s placeholder for the role name.
-    Example: "acme-gbl-root-%s" would produce role ARNs like "arn:aws:iam::123456789012:role/acme-gbl-root-admin"
-    If null, role names are used as-is (assumed to be full role names).
+    Map of account name/ID to IAM role name template for that account.
+    Each template should be a format string with a single %s placeholder for the role name.
+    Example: { "identity" = "acme-gbl-identity-%s", "dev" = "acme-gbl-dev-%s" }
+
+    This allows different accounts to have different role naming conventions.
+    When an account is not found in this map, the role name is used as-is.
   EOT
-  default     = null
+  default     = {}
 }

--- a/src/modules/assume-role-policy/variables.tf
+++ b/src/modules/assume-role-policy/variables.tf
@@ -73,24 +73,34 @@ variable "use_organization_id" {
 
 variable "account_map" {
   type = object({
-    full_account_map = map(string)
+    full_account_map       = map(string)
+    iam_role_arn_templates = optional(map(string), {})
   })
   description = <<-EOT
-    Static account map for resolving account names to account IDs.
+    Account map for resolving account names to account IDs and IAM role ARN templates.
     Required when using account names (non-numeric keys) in allowed_roles, denied_roles, allowed_permission_sets, or denied_permission_sets.
+
+    - full_account_map: Map of account name to account ID
+    - iam_role_arn_templates: Map of account name to IAM role ARN template with single %s placeholder for role name
+      (e.g., { "identity" = "arn:aws:iam::123456789012:role/acme-core-gbl-identity-%s" })
   EOT
   default = {
-    full_account_map = {}
+    full_account_map       = {}
+    iam_role_arn_templates = {}
   }
 }
 
 variable "iam_role_arn_template" {
   type        = string
   description = <<-EOT
-    Template for constructing IAM role names from account and role names.
+    Fallback template for constructing IAM role names when no per-account template exists.
     Should be a format string with two %s placeholders: first for account name, second for role name.
     Example: "acme-gbl-%s-%s" would produce role names like "acme-gbl-identity-admin"
-    If null, role names are used as-is (assumed to be full role names).
+
+    Note: Per-account templates from account_map.iam_role_arn_templates take precedence.
+    Those templates use a single %s placeholder for just the role name.
+
+    If null and no per-account template exists, role names are used as-is.
   EOT
   default     = null
 }

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -10,14 +10,20 @@ variable "account_map_enabled" {
 
 variable "account_map" {
   type = object({
-    full_account_map = map(string)
+    full_account_map       = map(string)
+    iam_role_arn_templates = optional(map(string), {})
   })
   description = <<-EOT
     Static account map used when account_map_enabled is false.
     Provides account name to account ID mapping without requiring the account-map component.
+
+    - full_account_map: Map of account name to account ID
+    - iam_role_arn_templates: Optional map of account name to IAM role ARN template
+      (e.g., { "identity" = "arn:aws:iam::123456789012:role/acme-gbl-identity-%s" })
     EOT
   default = {
-    full_account_map = {}
+    full_account_map       = {}
+    iam_role_arn_templates = {}
   }
 }
 

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -10,8 +10,9 @@ variable "account_map_enabled" {
 
 variable "account_map" {
   type = object({
-    full_account_map       = map(string)
-    iam_role_arn_templates = optional(map(string), {})
+    full_account_map              = map(string)
+    iam_role_arn_templates        = optional(map(string), {})
+    identity_account_account_name = optional(string, "identity")
   })
   description = <<-EOT
     Static account map used when account_map_enabled is false.
@@ -20,10 +21,12 @@ variable "account_map" {
     - full_account_map: Map of account name to account ID
     - iam_role_arn_templates: Optional map of account name to IAM role ARN template
       (e.g., { "identity" = "arn:aws:iam::123456789012:role/acme-gbl-identity-%s" })
+    - identity_account_account_name: Name of the identity account (default: "identity")
     EOT
   default = {
-    full_account_map       = {}
-    iam_role_arn_templates = {}
+    full_account_map              = {}
+    iam_role_arn_templates        = {}
+    identity_account_account_name = "identity"
   }
 }
 

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -27,30 +27,6 @@ variable "account_map" {
   }
 }
 
-variable "account_map_component_name" {
-  type        = string
-  description = "The name of the account-map component"
-  default     = "account-map"
-}
-
-variable "account_map_tenant" {
-  type        = string
-  description = "The tenant where the account-map component is deployed (defaults to current tenant)"
-  default     = "core"
-}
-
-variable "account_map_environment" {
-  type        = string
-  description = "The environment where the account-map component is deployed (e.g., 'gbl')"
-  default     = "gbl"
-}
-
-variable "account_map_stage" {
-  type        = string
-  description = "The stage where the account-map component is deployed (e.g., 'root')"
-  default     = "root"
-}
-
 provider "aws" {
   region = var.region
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,3 +1,27 @@
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}
+
+variable "account_map_tenant" {
+  type        = string
+  description = "The tenant where the account-map component is deployed (defaults to current tenant)"
+  default     = "core"
+}
+
+variable "account_map_environment" {
+  type        = string
+  description = "The environment where the account-map component is deployed (e.g., 'gbl')"
+  default     = "gbl"
+}
+
+variable "account_map_stage" {
+  type        = string
+  description = "The stage where the account-map component is deployed (e.g., 'root')"
+  default     = "root"
+}
+
 # Remote state lookup for the account-map component (or fallback to static mapping).
 #
 # When account_map_enabled is true:

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,3 +1,9 @@
+variable "privileged" {
+  type        = bool
+  description = "True if the Terraform user already has access to the backend"
+  default     = false
+}
+
 variable "account_map_component_name" {
   type        = string
   description = "The name of the account-map component"
@@ -42,6 +48,8 @@ module "account_map" {
   stage       = var.account_map_stage
 
   context = module.this.context
+
+  privileged = var.privileged
 
   # When account_map is disabled, bypass remote state and use the static account_map variable
   bypass   = !var.account_map_enabled

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -85,5 +85,5 @@ variable "use_organization_id" {
     If `false`, each account root is listed individually in the principals block, which may hit
     the trust policy size limit in larger organizations.
   EOT
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
## What

This PR fixes breaking changes introduced in v2 of the tfstate-backend component and restores backward compatibility for pre-v2 users.

### Changes
- **iam.tf**: Use per-account `iam_role_arn_templates` from account_map when available, with fallback template for static configurations
- **assume-role-policy submodule**: 
  - Support per-account full ARN templates (single `%s`) alongside fallback templates (two `%s`)
  - Auto-generate team permission set ARNs from identity account role names
  - Add default deny statement for IAM users (restoring pre-v2 behavior)
- **variables**: Add `privileged`, `team_permission_sets_enabled`, `team_permission_set_name_pattern` variables
- **defaults**: Set `use_organization_id = false` for backward compatibility

## Why

The v2 release unintentionally introduced breaking changes when the `assume-role-policy` submodule replaced the shared `team-assume-role-policy` module from account-map. Several features were lost in the transition:

1. **Incorrect role ARN templates**: Used `module.this.id` (deploying context like `use1-root`) instead of target account context (`gbl-identity`)
2. **Missing team permission sets**: Auto-generated SSO permission sets from identity account roles were removed
3. **Missing IAM user deny statement**: The default deny for IAM users was removed
4. **Changed defaults**: `use_organization_id` was introduced with default `true` instead of `false`

**Example of the original bug:**
- tfstate-backend deployed in `use1-root`
- Looking up `planners` role in `identity` account
- **Expected**: `arn:aws:iam::123:role/acme-core-gbl-identity-planners`
- **Got**: `arn:aws:iam::123:role/acme-core-use1-root-planners`

## Impact by Customer Type

### Pre-v2 Customers (with account_map)

Users upgrading from versions before the v2 breaking change will see their original behavior restored:

| Change | Impact |
|--------|--------|
| Role ARN order | Cosmetic only (reordering) |
| Permission set additions | Expected (e.g., adding AdministratorAccess) |
| `aws_iam_role_policy` resource | New resource (was inline_policy) - same policy content |

**No security behavior changes** - the deny statement already existed in their policies.

### Post-v2 Customers (without account_map)

Users who implemented tfstate-backend after v2 will see a new `RoleDenyAssumeRole` statement added:

```hcl
{
  Sid    = "RoleDenyAssumeRole"
  Effect = "Deny"
  Condition = {
    ArnLike      = { "aws:PrincipalArn" = "arn:aws:iam::*:user/*" }
    ArnNotEquals = { "aws:PrincipalArn" = [/* explicitly allowed principals */] }
  }
}
```

**This is a security improvement** that should have been included in v2 initially. It:
- Denies all IAM users by default
- Excepts explicitly allowed principals (e.g., SuperAdmin)
- Matches the security posture of pre-v2 deployments

This change is safe as long as only SuperAdmin and assumed roles (terraform, planner, etc.) need to access tfstate. If other IAM users require access, set `iam_users_enabled = true`.

## Important: `use_organization_id` Default Change

The `use_organization_id` variable was introduced in v2 but with an incorrect default of `true`. This PR corrects the default to `false`.

| Version | Status | Behavior |
|---------|--------|----------|
| Pre-v2 | Did not exist | Individual account root ARNs listed in principals |
| V2 | Introduced with default `true` | Uses `aws:PrincipalOrgID` condition with `*` principal |
| This PR | Default corrected to `false` | Individual account root ARNs (matches pre-v2 behavior) |

**Action Required for Recent V2 Adopters:** If you implemented tfstate-backend between the v2 release and this patch (approximately 1-2 weeks), you will need to explicitly set `use_organization_id: true` in your stack configuration to maintain your current behavior and avoid reverting to individual account root ARNs.

```yaml
components:
  terraform:
    tfstate-backend:
      vars:
        use_organization_id: true  # Preserve v2 behavior
```

## How It Works Now

### Role ARN Template Priority
1. **Per-account template** from `account_map.iam_role_arn_templates` (full ARN with single `%s` for role name)
2. **Fallback template** constructed from context (two `%s` for account + role)
3. **Role name as-is** if no template provided

### Team Permission Sets
When `team_permission_sets_enabled = true` (default), role names in the identity account are automatically converted to SSO permission set ARN patterns:
- `developers` → `arn:aws:iam::{identity_id}:role/aws-reserved/sso.amazonaws.com*/AWSReservedSSO_IdentityDevelopersTeamAccess_*`

### IAM User Deny
The `RoleDenyAssumeRole` statement is always created (unless `iam_users_enabled = true`) and denies:
- All IAM users (`arn:aws:iam::*:user/*`)
- Any explicitly denied principals/roles/permission sets
- With exceptions for explicitly allowed principals

## Upgrade Recommendation

1. Run `terraform plan` to review changes before applying
2. For pre-v2 customers: Changes should be minimal (ordering, new resources)
3. For post-v2 customers: Review the new deny statement - set `iam_users_enabled = true` if needed
4. **For recent v2 adopters**: Set `use_organization_id: true` to preserve current behavior
5. Apply during maintenance window if concerned about brief access changes

## References

- Reported via community feedback about v1.537.3 breaking IAM role lookups
- Original issue: Role names used deploying context instead of target account context