### PR TITLE
feat: route SSO permission set callers to allowed_permission_sets to prevent drift

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -71,11 +71,20 @@ access. You can configure who is allowed to assume these roles.
   therefore unlikely vector of attack. (Also note that the entire DynamoDB table is optional and can be deleted
   entirely; Terraform will repopulate it as new activity takes place.)
 
-- For convenience, the component automatically grants access to the backend to the user deploying it. This is helpful
-  because it allows that user, presumably SuperAdmin, to deploy the normal components that expect the user does not have
-  direct access to Terraform state, without requiring custom configuration. However, you may want to explicitly grant
-  SuperAdmin access to the backend in the `allowed_principal_arns` configuration, to ensure that SuperAdmin can always
-  access the backend, even if the component is later updated by the `root-admin` role.
+- **Self-Access Protection**: The component automatically grants access to the backend to the identity (user or role)
+  deploying it. This is a critical safety mechanism that prevents you from accidentally removing your own access to the
+  Terraform state, which would lock you out and require manual AWS Console intervention to fix.
+
+  - For **SSO permission sets** (e.g., `TerraformApplyAccess`), the component extracts the account ID and permission set
+    name and adds them to `allowed_permission_sets`. This ensures the permission set ARN pattern is used rather than the
+    specific user's session ARN, which would cause drift every time a different user runs Terraform.
+
+  - For **regular IAM roles or users**, the component adds the caller's ARN directly to `allowed_principal_arns`.
+
+  **Important**: To prevent drift and ensure consistent state, you should explicitly include the identities that will
+  apply this component in your `allowed_permission_sets` or `allowed_principal_arns` configuration. For example, if you
+  apply this component using the `TerraformApplyAccess` permission set from the root account, add it to
+  `allowed_permission_sets`. This way, the caller's identity is already in the allowed list and won't cause changes.
 
 ### Quotas
 
@@ -226,12 +235,11 @@ terraform:
 ## References
 
 
-- [Provision tfstate-backend component](https://docs.cloudposse.com/layers/accounts/tutorials/manual-configuration/#provision-tfstate-backend-component) - 
+- [Provision tfstate-backend component](https://docs.cloudposse.com/layers/accounts/tutorials/manual-configuration/#provision-tfstate-backend-component) -
 
-- [Increase IAM role trust policy character limit](https://us-east-1.console.aws.amazon.com/servicequotas/home/services/iam/quotas/L-C07B4B0D) - 
+- [Increase IAM role trust policy character limit](https://us-east-1.console.aws.amazon.com/servicequotas/home/services/iam/quotas/L-C07B4B0D) -
 
 
 
 
 [<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tfstate-backend&utm_content=)
-

--- a/src/iam.tf
+++ b/src/iam.tf
@@ -14,7 +14,29 @@ locals {
   #    arn:aws:sts::123456789012:assumed-role/acme-core-gbl-root-admin/aws-go-sdk-1722029959251053170
   # to the IAM Role ARN, like
   #    arn:aws:iam::123456789012:role/acme-core-gbl-root-admin
-  caller_arn = coalesce(data.awsutils_caller_identity.current.eks_role_arn, data.awsutils_caller_identity.current.arn)
+  caller_arn_raw = coalesce(data.awsutils_caller_identity.current.eks_role_arn, data.awsutils_caller_identity.current.arn)
+
+  # Check if the caller is an SSO permission set role
+  caller_is_sso_role = can(regex("AWSReservedSSO_", local.caller_arn_raw))
+
+  # For SSO permission set roles, extract the account ID and permission set name.
+  # These are added to allowed_permission_sets (not allowed_principal_arns) to avoid drift
+  # when different users with the same permission set run terraform.
+  # Example ARN: arn:aws:iam::123456789012:role/AWSReservedSSO_TerraformApplyAccess_bd2360a3f5507778
+  # Extracted: account_id=123456789012, permission_set_name=TerraformApplyAccess
+  caller_sso_parts = local.caller_is_sso_role ? regex(
+    "^arn:([^:]+):iam::([0-9]+):role/AWSReservedSSO_(.+)_([a-f0-9]{16})$",
+    local.caller_arn_raw
+  ) : null
+
+  # For non-SSO callers, use the raw ARN directly
+  # For SSO callers, this will be null (they go into allowed_permission_sets instead)
+  caller_arn = local.caller_is_sso_role ? null : local.caller_arn_raw
+
+  # For SSO callers, extract account ID and permission set name to add to allowed_permission_sets
+  caller_permission_set = local.caller_is_sso_role ? {
+    (local.caller_sso_parts[1]) = [local.caller_sso_parts[2]] # account_id = [permission_set_name]
+  } : {}
 
   # Fallback IAM role name template used when per-account templates are not available
   # (i.e., when account_map_enabled is false and no iam_role_arn_templates provided)
@@ -57,9 +79,9 @@ module "assume_role" {
 
   allowed_roles           = each.value.allowed_roles
   denied_roles            = each.value.denied_roles
-  allowed_principal_arns  = distinct(concat(each.value.allowed_principal_arns, [local.caller_arn]))
+  allowed_principal_arns  = distinct(concat(each.value.allowed_principal_arns, compact([local.caller_arn])))
   denied_principal_arns   = each.value.denied_principal_arns
-  allowed_permission_sets = try(each.value.allowed_permission_sets, {})
+  allowed_permission_sets = merge(try(each.value.allowed_permission_sets, {}), local.caller_permission_set)
   denied_permission_sets  = try(each.value.denied_permission_sets, {})
 
   account_map           = module.account_map.outputs
@@ -115,14 +137,21 @@ resource "aws_iam_role_policy" "default" {
 # Cold start access policy - used when access_roles_enabled is false
 # This allows the caller and explicitly allowed principals to assume the role during initial setup
 locals {
-  all_cold_start_access_principals = local.cold_start_access_enabled ? toset(concat([local.caller_arn],
+  # Filter out wildcard ARNs - they can't be used to derive account root principals
+  # Wildcard ARNs are still used in the ArnLike condition, but principals must be concrete
+  # Note: Use caller_arn_raw here since caller_arn is null for SSO callers (they're handled via allowed_permission_sets)
+  all_cold_start_access_principals_raw = local.cold_start_access_enabled ? toset(concat([local.caller_arn_raw],
   flatten([for k, v in local.access_roles : v.allowed_principal_arns]))) : toset([])
+  all_cold_start_access_principals = toset([for arn in local.all_cold_start_access_principals_raw : arn if !strcontains(arn, "*")])
+
   cold_start_access_principal_arns = local.cold_start_access_enabled ? { for k, v in local.access_roles : k => distinct(concat(
-    [local.caller_arn], v.allowed_principal_arns
+    [local.caller_arn_raw], v.allowed_principal_arns
   )) } : {}
+
+  # Only use non-wildcard ARNs for deriving account root principals
   cold_start_access_principals = local.cold_start_access_enabled ? {
     for k, v in local.cold_start_access_principal_arns : k => formatlist("arn:%v:iam::%v:root", data.aws_partition.current.partition, distinct([
-      for arn in v : data.aws_arn.cold_start_access[arn].account
+      for arn in v : data.aws_arn.cold_start_access[arn].account if !strcontains(arn, "*")
     ]))
   } : {}
 }


### PR DESCRIPTION
## What

When the caller identity is an AWS SSO permission set role (e.g., `TerraformApplyAccess`), this change routes it to `allowed_permission_sets` instead of `allowed_principal_arns`. This prevents drift when different users with the same permission set run Terraform.

### Changes

1. **SSO permission set detection**: Added logic to detect if the caller is using an SSO permission set by checking for `AWSReservedSSO_` in the role ARN.

2. **Permission set extraction**: For SSO callers, extracts the account ID and permission set name from the ARN pattern:
   - From: `arn:aws:iam::123456789012:role/AWSReservedSSO_TerraformApplyAccess_bd2360a3f5507778`
   - Extracted: `{ "123456789012" = ["TerraformApplyAccess"] }`

3. **Correct routing**:
   - SSO permission sets → merged into `allowed_permission_sets` (PermissionSetAssumeRole statement)
   - Regular IAM roles/users → added to `allowed_principal_arns` (PrincipalAssumeRole statement)

4. **Cold start fix**: Updated cold start handling to:
   - Use `caller_arn_raw` (since `caller_arn` is now null for SSO callers)
   - Filter out wildcard ARNs when deriving account root principals

5. **Documentation**: Updated README with detailed explanation of the self-access protection mechanism.

## Why

Previously, SSO permission set callers were added to `allowed_principal_arns` with their specific instance ID suffix (e.g., `_bd2360a3f5507778`). This caused drift every time a different user with the same permission set ran Terraform, because each user gets a unique instance ID.

By routing SSO callers to `allowed_permission_sets`, the component generates a wildcard ARN pattern that matches any user with that permission set, eliminating drift.

## References

- The self-access protection mechanism is critical to prevent users from accidentally locking themselves out of the Terraform state backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote Self-Access Protection guidance to clarify how the deploying identity is granted backend access and how to list SSO permission sets or IAM principals to avoid configuration drift.

* **New Features**
  * Added SSO-aware access control that separates SSO permission-set entries from IAM principal entries and filters wildcard principals for safer access handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->