### PR TITLE
fix: lift aws provider cap to < 7.0.0 and match region-less SSO permission-set roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,14 +187,14 @@ terraform:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 7.0.0 |
 | <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.16.0, < 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 7.0.0 |
 | <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.16.0, < 6.0.0 |
 
 ## Modules

--- a/src/README.md
+++ b/src/README.md
@@ -136,14 +136,14 @@ terraform:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 7.0.0 |
 | <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.16.0, < 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 7.0.0 |
 | <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.16.0, < 6.0.0 |
 
 ## Modules

--- a/src/modules/assume-role-policy/main.tf
+++ b/src/modules/assume-role-policy/main.tf
@@ -105,19 +105,24 @@ locals {
   ])) : []
 
   # Convert allowed_permission_sets map (account_name/id -> [permission_set_names]) to ARN patterns
-  # AWS SSO permission set IAM role ARN format: arn:aws:iam::ACCOUNT_ID:role/aws-reserved/sso.amazonaws.com/REGION/AWSReservedSSO_PERMISSION_SET_NAME_ID
-  # The * wildcard matches the region path (e.g., /us-east-2) and the permission set instance ID suffix
+  # AWS SSO permission set IAM role ARN format: arn:aws:iam::ACCOUNT_ID:role/aws-reserved/sso.amazonaws.com[/REGION]/AWSReservedSSO_PERMISSION_SET_NAME_ID
+  # The region path segment is OPTIONAL: IAM Identity Center instances homed in us-east-1 provision
+  # permission-set roles with no region segment (.../sso.amazonaws.com/AWSReservedSSO_...), while other
+  # home regions include it (.../sso.amazonaws.com/us-east-2/AWSReservedSSO_...). The `com*/` glob matches
+  # both (it absorbs an optional `/REGION`), whereas `com/*/` would require a region and 403 on us-east-1
+  # instances. This mirrors the region-optional form used by team_permission_set_arns above.
   allowed_permission_set_arns = local.enabled ? distinct(flatten([
     for account_key, permission_sets in var.allowed_permission_sets : [
-      for ps_name in permission_sets : format("arn:%s:iam::%s:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_%s_*",
+      for ps_name in permission_sets : format("arn:%s:iam::%s:role/aws-reserved/sso.amazonaws.com*/AWSReservedSSO_%s_*",
       data.aws_partition.current[0].partition, local.get_account_id[account_key], ps_name)
     ]
   ])) : []
 
   # Convert denied_permission_sets map (account_name/id -> [permission_set_names]) to ARN patterns
+  # Region-optional glob, same as allowed_permission_set_arns above (see note there).
   denied_permission_set_arns = local.enabled ? distinct(flatten([
     for account_key, permission_sets in var.denied_permission_sets : [
-      for ps_name in permission_sets : format("arn:%s:iam::%s:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_%s_*",
+      for ps_name in permission_sets : format("arn:%s:iam::%s:role/aws-reserved/sso.amazonaws.com*/AWSReservedSSO_%s_*",
       data.aws_partition.current[0].partition, local.get_account_id[account_key], ps_name)
     ]
   ])) : []

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 6.0.0"
+      version = ">= 4.9.0, < 7.0.0"
     }
     awsutils = {
       source  = "cloudposse/awsutils"


### PR DESCRIPTION
## what

Two independent fixes (one commit each):

1. **Lift the `hashicorp/aws` provider constraint** from `>= 4.9.0, < 6.0.0` to `>= 4.9.0, < 7.0.0` (`src/versions.tf`, README regenerated).
2. **Fix the SSO permission-set trust ARN glob** in `src/modules/assume-role-policy/main.tf` so it matches permission-set roles that have no region path segment (IAM Identity Center instances homed in `us-east-1`).

## why

### 1. aws provider `< 6.0.0` cap blocks state written by aws 6.x

The aws provider 6.x series added a `region` attribute to `aws_s3_bucket_versioning`, `aws_s3_bucket_acl`, and `aws_s3_bucket_server_side_encryption_configuration`. Once the component's state has been written by a 6.x provider, a 5.x provider can no longer decode it:

```
Error: Resource instance managed by newer provider version
```

Older releases of this component had no upper bound and ran on aws 6.x for months, so consumers have state written by 6.x and cannot downgrade. `terraform plan`/`apply` on the current version with aws 6.x is clean, producing only deprecation warnings and no errors. The `< 6.0.0` cap therefore blocks a working configuration, so relax it to `< 7.0.0`.

(`awsutils` cap left unchanged, as it is unaffected.)

### 2. SSO permission-set ARNs require a region path segment that us-east-1 omits

`allowed_permission_set_arns` and `denied_permission_set_arns` render the trust-policy pattern as:

```
arn:...:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_<name>_*
```

The `/*/` requires a region path segment. IAM Identity Center instances homed in **us-east-1** provision permission-set roles with **no** region segment:

```
arn:...:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_<name>_*
```

so those trust statements silently never match and `AssumeRole` returns 403. Instances homed elsewhere include the segment (`.../sso.amazonaws.com/us-east-2/...`).

Switching to the region-optional `com*/` glob (which absorbs an optional `/REGION`) matches both forms. This is already the form used by the `team_permission_set_arns` local in the same file and by the `allowed_permission_sets` docstring in `variables.tf`, so this change simply makes the `allowed`/`denied` renderings consistent with them.

## references

- IAM Identity Center reserved-role ARN path is region-optional depending on the instance's home region.
- Same region-optional glob is already used in `team_permission_set_arns` (`main.tf`) and documented in `variables.tf`.

## test

- `terraform fmt`, `terraform init -backend=false`, `terraform validate` pass in `src/` (validate emits only a pre-existing `aws_region.name` deprecation warning from a child module, unrelated to this change).
- No changes to variables/outputs or account-map versions, so terratest fixtures are unaffected; the Go suite makes no assertions on the SSO ARN glob string.